### PR TITLE
Feature/worker/#37

### DIFF
--- a/app.cpp
+++ b/app.cpp
@@ -123,12 +123,11 @@ static void user_system_create() {
         gSwithEdgeDetector,
     };
 
-    gDriver = new Driver(gUptime, gLineMonitor, gLeftWheel, gRightWheel,
-                         gDiagnostics);
+    gDriver = new Driver(gLeftWheel, gRightWheel, gDiagnostics);
 
-    gStayInPlace = new StayInPlace(gDriver);
-    gLineWalker = new LineWalker(gDriver);
-    gSampleWalker = new SampleWalker(gDriver);
+    gStayInPlace = new StayInPlace();
+    gLineWalker = new LineWalker(gUptime, gLineMonitor);
+    gSampleWalker = new SampleWalker();
 
     Walker* walkers[] = {
         gStayInPlace,
@@ -136,7 +135,7 @@ static void user_system_create() {
         gSampleWalker,
     };
 
-    gScenarioWalker = new ScenarioWalker(gScenarioReader,
+    gScenarioWalker = new ScenarioWalker(gScenarioReader, gDriver,
             monitors, sizeof(monitors) / sizeof(monitors[0]),
             detectors, sizeof(detectors) / sizeof(detectors[0]),
             walkers, sizeof(walkers) / sizeof(walkers[0]));

--- a/app/ScenarioWalker.cpp
+++ b/app/ScenarioWalker.cpp
@@ -118,10 +118,8 @@ public:
         }
     }
 
-    void run() {
-        if (mCurrentWalker) {
-            mCurrentWalker->run();
-        }
+    Walker* getCurrentWalker() {
+        return mCurrentWalker;
     }
 
     void goToScene(int index) {
@@ -152,11 +150,11 @@ private:
 };
 
 ScenarioWalker::ScenarioWalker(
-        ScenarioReader* scenario,
+        ScenarioReader* scenario, Driver* driver,
         Monitor* monitors[], int monitorsNum,
         Detector* detectors[], int detectorsNum,
         Walker* walkers[], int walkersNum)
-    : mScenario(scenario), mState(UNDEFINED), mSceneIndex(),
+    : mScenario(scenario), mDriver(driver), mState(UNDEFINED), mSceneIndex(),
       mMonitors(new MonitorsImpl(monitors, monitorsNum, mScenario)),
       mDetectors(new DetectorsImpl(detectors, detectorsNum, mScenario)),
       mWalkers(new WalkersImpl(walkers, walkersNum, mScenario)) {}
@@ -186,7 +184,7 @@ void ScenarioWalker::execScenarioWalking() {
         mWalkers->goToScene(mSceneIndex);
         mDetectors->goToScene(mSceneIndex);
     }
-    mWalkers->run();
+    mDriver->run(mWalkers->getCurrentWalker());
 }
 
 void ScenarioWalker::run() {

--- a/app/ScenarioWalker.cpp
+++ b/app/ScenarioWalker.cpp
@@ -39,10 +39,13 @@ public:
         }
     }
 
-    void update() {
+    bool update() {
         for (int i = 0; i < mMonitorsNum; ++i) {
-            mMonitors[i]->update();
+            if (!mMonitors[i]->update()) {
+                return false;
+            }
         }
+        return true;
     }
 
 private:
@@ -177,7 +180,9 @@ void ScenarioWalker::execUndefined() {
 }
 
 void ScenarioWalker::execScenarioWalking() {
-    mMonitors->update();
+    if (!mMonitors->update()) {
+        mDriver->stop();
+    }
     if (mDetectors->isSceneTerminate()) {
         ++mSceneIndex;
         printf("**** Start Scene %d ****\n", mSceneIndex);

--- a/app/ScenarioWalker.h
+++ b/app/ScenarioWalker.h
@@ -14,6 +14,7 @@
 #include "Monitor.h"
 #include "Detector.h"
 #include "Walker.h"
+#include "Driver.h"
 
 class MonitorsImpl;
 class DetectorsImpl;
@@ -21,7 +22,7 @@ class WalkersImpl;
 
 class ScenarioWalker {
 public:
-    ScenarioWalker(ScenarioReader* scenario,
+    ScenarioWalker(ScenarioReader* scenario, Driver* driver,
                    Monitor* monitors[], int monitorsNum,
                    Detector* detectors[], int detectorsNum,
                    Walker* walkers[], int walkerNum);
@@ -35,6 +36,7 @@ private:
     void execScenarioWalking();
 
     ScenarioReader* mScenario;
+    Driver* mDriver;
     int mState;
     int mSceneIndex;
 

--- a/monitor/LineMonitor.cpp
+++ b/monitor/LineMonitor.cpp
@@ -64,7 +64,7 @@ static double min(const double rgb[3]) {
     }
 }
 
-void LineMonitor::update() {
+bool LineMonitor::update() {
     double* rgb = mContext->rgb;
     double* hsv = mContext->hsv;
     double& y = mContext->y;
@@ -101,6 +101,8 @@ void LineMonitor::update() {
     // v = 0.500 * rgb[0] - 0.419 * rgb[1] - 0.081 * rgb[2];
 
     mDiag->setColor(rgb, hsv, y);
+
+    return true;
 }
 
 double LineMonitor::getBrightness() const { return mContext->y; }

--- a/monitor/LineMonitor.h
+++ b/monitor/LineMonitor.h
@@ -28,7 +28,7 @@ public:
 
   virtual void init(const ScenarioParams& params);
 
-  virtual void update();
+  virtual bool update();
 
   virtual const char* getClassName() const;
 

--- a/monitor/Monitor.h
+++ b/monitor/Monitor.h
@@ -14,7 +14,7 @@ public:
 
   virtual void init(const ScenarioParams& params);
 
-  virtual void update() = 0;
+  virtual bool update() = 0;
 
   virtual const char* getClassName() const = 0;
 };

--- a/monitor/PoseEstimator.cpp
+++ b/monitor/PoseEstimator.cpp
@@ -22,12 +22,13 @@ public:
     gyro.reset();
   }
 
-  void update() {
+  bool update() {
     double lc = float(left.getCount()),
            rc = float(right.getCount()),
            yaw = float(gyro.getAngle()),
            w = float(gyro.getAnglerVelocity());
     diag->setMeasure(lc, rc, yaw, w);
+    return true;
   }
 };
 
@@ -43,4 +44,4 @@ void PoseEstimator::init(const ScenarioParams& params) {
   mImpl->init(params);
 }
 
-void PoseEstimator::update() { mImpl->update(); }
+bool PoseEstimator::update() { return mImpl->update(); }

--- a/monitor/PoseEstimator.h
+++ b/monitor/PoseEstimator.h
@@ -21,7 +21,7 @@ public:
 
   virtual void init(const ScenarioParams& params);
 
-  virtual void update();
+  virtual bool update();
 
   virtual const char* getClassName() const;
 

--- a/monitor/Uptime.cpp
+++ b/monitor/Uptime.cpp
@@ -37,6 +37,9 @@ const char* Uptime::getClassName() const { return "Uptime"; }
 
 void Uptime::init(const ScenarioParams& params) { mImpl->init(); }
 
-void Uptime::update() { mImpl->update(); }
+bool Uptime::update() {
+  mImpl->update();
+  return true;
+}
 
 double Uptime::getUptime() const { return mImpl->getUptime(); }

--- a/monitor/Uptime.h
+++ b/monitor/Uptime.h
@@ -19,7 +19,7 @@ public:
 
   virtual void init(const ScenarioParams& params);
 
-  virtual void update();
+  virtual bool update();
 
   virtual const char* getClassName() const;
 

--- a/walker/Driver.h
+++ b/walker/Driver.h
@@ -6,30 +6,23 @@
 #ifndef EV3_WALKER_DRIVER_H_
 #define EV3_WALKER_DRIVER_H_
 
-#include "Uptime.h"
-#include "LineMonitor.h"
+#include "Walker.h"
 #include "Motor.h"
 #include "Diagnostics.h"
 
 class Driver {
 public:
-  Driver(Uptime* uptime,
-         LineMonitor* lineMonitor,
-         ev3api::Motor& leftWheel,
+  Driver(ev3api::Motor& leftWheel,
          ev3api::Motor& rightWheel,
          Diagnostics* diag);
 
+  void run(Walker* walker);
+
   void stop();
 
+private:
   void setDriveParam(int leftPWM, int rightPWM);
 
-  double getBrightness() const;
-
-  double getUptime() const;
-
-private:
-  Uptime* mUptime;
-  LineMonitor* mLineMonitor;
   ev3api::Motor& mLeftWheel;
   ev3api::Motor& mRightWheel;
   Diagnostics* mDiag;

--- a/walker/LineWalker.h
+++ b/walker/LineWalker.h
@@ -10,21 +10,26 @@
 #define EV3_WALKER_LINE_WALKER_H_
 
 #include "Walker.h"
+#include "LineMonitor.h"
+#include "Uptime.h"
 
 class LineWalker : public Walker {
 public:
-    LineWalker(Driver* driver);
+    LineWalker(Uptime* uptime, LineMonitor* lineMonitor);
 
     virtual ~LineWalker();
 
     virtual const char* getClassName() const;
 
     virtual void reset(const ScenarioParams& params);
+ 
+    virtual bool execute();
 
-    virtual void run();
+    virtual Control get();
 
 private:
-    double steeringAmountCalculation(double brightness);
+    Uptime* mUptime;
+    LineMonitor* mLineMonitor;
 
     double mEdge;
     double mWhilteBrightness;
@@ -36,6 +41,7 @@ private:
     double mPrevTime;
     double mIntegral;
     double mBaseSpeed;
+    double mSteeringAmount;
 };
 
 #endif  // EV3_WALKER_LINE_WALKER_H_

--- a/walker/SampleWalker.cpp
+++ b/walker/SampleWalker.cpp
@@ -5,7 +5,7 @@
 
 #include "SampleWalker.h"
 
-SampleWalker::SampleWalker(Driver* driver) : Walker(driver) {}
+SampleWalker::SampleWalker() {}
 
 SampleWalker::~SampleWalker() {}
 
@@ -13,8 +13,8 @@ const char* SampleWalker::getClassName() const {
   return "SampleWalker";
 }
 
-void SampleWalker::run() {
-  double brightness = getBrightness();
-  int left = 30, right = 30;
-  setDriveParam(left, right);
+bool SampleWalker::execute() {
+  return true;
 }
+
+Control SampleWalker::get() { return Control(40, 40); }

--- a/walker/SampleWalker.h
+++ b/walker/SampleWalker.h
@@ -10,11 +10,13 @@
 
 class SampleWalker : public Walker {
 public:
-  SampleWalker(Driver* driver);
+  SampleWalker();
 
   virtual ~SampleWalker();
 
-  virtual void run();
+  virtual bool execute();
+
+  virtual Control get();
 
   virtual const char* getClassName() const;
 };

--- a/walker/StayInPlace.cpp
+++ b/walker/StayInPlace.cpp
@@ -5,17 +5,6 @@
 
 #include "StayInPlace.h"
 
-StayInPlace::StayInPlace(Driver* driver) : Walker(driver) {}
-
-StayInPlace::~StayInPlace() {}
-
 const char* StayInPlace::getClassName() const {
   return "StayInPlace";
-}
-
-void StayInPlace::reset(const ScenarioParams& params) {
-  stop();
-}
-
-void StayInPlace::run() {
 }

--- a/walker/StayInPlace.h
+++ b/walker/StayInPlace.h
@@ -10,14 +10,6 @@
 
 class StayInPlace : public Walker {
 public:
-  StayInPlace(Driver* driver);
-
-  virtual ~StayInPlace();
-
-  virtual void reset(const ScenarioParams& params);
-
-  virtual void run();
-
   virtual const char* getClassName() const;
 };
 

--- a/walker/Walker.cpp
+++ b/walker/Walker.cpp
@@ -5,7 +5,10 @@
 
 #include "Walker.h"
 
-Walker::Walker(Driver* driver) : mDriver(driver) {}
+Control::Control() : speed(), steering() {}
+
+Control::Control(double _speed, double _steering)
+  : speed(_speed), steering(_steering) {}
 
 Walker::~Walker() {}
 
@@ -13,18 +16,6 @@ void Walker::init() { return; }
 
 void Walker::reset(const ScenarioParams& params) { return; }
 
-void Walker::stop() {
-  mDriver->stop();
-}
+bool Walker::execute() { return false; }
 
-void Walker::setDriveParam(int leftPWM, int rightPWM) {
-  mDriver->setDriveParam(leftPWM, rightPWM);
-}
-
-double Walker::getBrightness() const {
-  return mDriver->getBrightness();
-}
-
-double Walker::getUptime() const {
-  return mDriver->getUptime();
-}
+Control Walker::get() { return Control(); }

--- a/walker/Walker.h
+++ b/walker/Walker.h
@@ -6,31 +6,29 @@
 #ifndef EV3_WALKER_WALKER_H_
 #define EV3_WALKER_WALKER_H_
 
-#include "Driver.h"
 #include "ScenarioParams.h"
+
+struct Control {
+  double speed;
+  double steering;
+
+  Control();
+  Control(double _speed, double _steering);
+};
 
 class Walker {
 public:
-  Walker(Driver* driver);
-
   virtual ~Walker();
 
   virtual void init();
 
   virtual void reset(const ScenarioParams& params);
 
-  virtual void run() = 0;
+  virtual bool execute();
+
+  virtual Control get();
 
   virtual const char* getClassName() const = 0;
-
-protected:
-  void stop();
-  void setDriveParam(int leftPWM, int rightPWM);
-  double getBrightness() const;
-  double getUptime() const;
-
-private:
-  Driver* mDriver;
 };
 
 #endif  // EV3_UNIT_WALKER_H_


### PR DESCRIPTION
実装を提出したモデルに合わせるために以下の修正を行います

- Walker interfaceの修正
  - ```Walker::execute()``` で制御量を計算して ```Walker::get()``` で制御量を返すようにしています
  - 制御量は↓です　https://github.com/owhinata/etrobo_tr_ex3/blob/a634477b54244b3b108ced18c666badfe300ce9f/walker/Walker.h#L11
  - Control.steeringは ```steering > 0``` で左に曲がる(右タイヤのPWM > 左タイヤのPWM)の方法です

- Monitor interfaceの修正
  - Monitor::update()の戻り値をboolとしています。

※　モデルでは ```走行体::実行する(測定値 : 測定値)``` でしたが、引数の測定値はあまり意味がなかったのでモデルには追随しませんでした。