### PR TITLE
feat: #55 Normailize hue observations in Detectors

### DIFF
--- a/detector/ColorAmplification.cpp
+++ b/detector/ColorAmplification.cpp
@@ -5,6 +5,7 @@
 
 #include "ColorAmplification.h"
 
+#include <math.h>
 #include <string.h>
 
 class ColorAmplification::Impl {
@@ -40,9 +41,19 @@ public:
            hue, count, amplification);
   }
 
+  static double normalize(double angle, double base) {
+    double min = base - 180.0;
+    angle = fmod(angle - min, 360) + min;
+    if (angle < min) {
+      angle += 360;
+    }
+    return angle;
+  }
+
   bool on() {
     hsv_raw_t hsv = color->getHsvColor();
-    if (hsv.h > hue - 30 && hsv.h < hue + 30) {
+    double h = normalize(hsv.h, hue);
+    if (h > hue - 30 && h < hue + 30) {
       ++detected;
     } else {
       detected = 0;

--- a/detector/ColorDetector.cpp
+++ b/detector/ColorDetector.cpp
@@ -5,6 +5,8 @@
 
 #include "ColorDetector.h"
 
+#include <math.h>
+
 static const double HUE = 204.0;
 static const double SATURATION = 0.36;
 static const int COUNT = 10;
@@ -35,9 +37,19 @@ public:
            hue, saturation, count);
   }
 
+  static double normalize(double angle, double base) {
+    double min = base - 180.0;
+    angle = fmod(angle - min, 360) + min;
+    if (angle < min) {
+      angle += 360;
+    }
+    return angle;
+  }
+
   bool on() {
     hsv = sensor->getHsvColor();
-    if (hsv.h > hue - 30 && hsv.h < hue + 30) {
+    double h = normalize(hsv.h, hue);
+    if (h > hue - 30 && h < hue + 30) {
       ++detected;
     } else {
       detected = 0;


### PR DESCRIPTION
例えば、赤色を-30°~30°の範囲で判断していると、Hueの観測値が350°とかだった場合に観測値をそのまま比較できない。

そのため、Hueの範囲を比較する際に、観測値をtarget値の周り±180°の範囲に正規化して比較するようにする。

Closes #55 